### PR TITLE
feat:新增支持openh264、opus、speex、webp四个多媒体编解码能力

### DIFF
--- a/harmony/ffmpeg_kit/src/main/cpp/CMakeLists.txt
+++ b/harmony/ffmpeg_kit/src/main/cpp/CMakeLists.txt
@@ -50,6 +50,16 @@ target_include_directories(rnoh_ffmpeg_kit PUBLIC
     ${THIRD_PARTY_DIR}/libtasn1/${OHOS_ARCH}/include
     ${THIRD_PARTY_DIR}/gnutls/${OHOS_ARCH}/include
     ${THIRD_PARTY_DIR}/chromaprint/${OHOS_ARCH}/include
+
+    ${THIRD_PARTY_DIR}/openh264/${OHOS_ARCH}/include
+    ${THIRD_PARTY_DIR}/opus/${OHOS_ARCH}/include
+    ${THIRD_PARTY_DIR}/speex/${OHOS_ARCH}/include
+    ${THIRD_PARTY_DIR}/libwebp/${OHOS_ARCH}/include
+    ${THIRD_PARTY_DIR}/zstd/${OHOS_ARCH}/include
+    ${THIRD_PARTY_DIR}/jbigkit/${OHOS_ARCH}/include
+    ${THIRD_PARTY_DIR}/libjpeg-turbo/${OHOS_ARCH}/include
+    ${THIRD_PARTY_DIR}/libdeflate/${OHOS_ARCH}/include
+    ${THIRD_PARTY_DIR}/tiff/${OHOS_ARCH}/include
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
@@ -89,6 +99,26 @@ target_link_libraries(rnoh_ffmpeg_kit PUBLIC ${THIRD_PARTY_DIR}/libtasn1/${OHOS_
 
 target_link_libraries(rnoh_ffmpeg_kit PUBLIC ${THIRD_PARTY_DIR}/chromaprint/${OHOS_ARCH}/lib/libchromaprint.so.1)
 
+# 2025.04.24  start
+target_link_libraries(rnoh_ffmpeg_kit PUBLIC ${THIRD_PARTY_DIR}/openh264/${OHOS_ARCH}/lib/libopenh264.so.7)
+target_link_libraries(rnoh_ffmpeg_kit PUBLIC ${THIRD_PARTY_DIR}/opus/${OHOS_ARCH}/lib/libopus.so.0)
+target_link_libraries(rnoh_ffmpeg_kit PUBLIC ${THIRD_PARTY_DIR}/speex/${OHOS_ARCH}/lib/libspeex.so.1)
+target_link_libraries(rnoh_ffmpeg_kit PUBLIC ${THIRD_PARTY_DIR}/zstd/${OHOS_ARCH}/lib/libzstd.so.1)
+target_link_libraries(rnoh_ffmpeg_kit PUBLIC ${THIRD_PARTY_DIR}/jbigkit/${OHOS_ARCH}/lib/libjbig.a)
+target_link_libraries(rnoh_ffmpeg_kit PUBLIC ${THIRD_PARTY_DIR}/libdeflate/${OHOS_ARCH}/lib/libdeflate.so.0)
+
+target_link_libraries(rnoh_ffmpeg_kit PUBLIC ${THIRD_PARTY_DIR}/libwebp/${OHOS_ARCH}/lib/libsharpyuv.so.0)
+target_link_libraries(rnoh_ffmpeg_kit PUBLIC ${THIRD_PARTY_DIR}/libwebp/${OHOS_ARCH}/lib/libwebp.so.7)
+target_link_libraries(rnoh_ffmpeg_kit PUBLIC ${THIRD_PARTY_DIR}/libwebp/${OHOS_ARCH}/lib/libwebpdecoder.so.3)
+target_link_libraries(rnoh_ffmpeg_kit PUBLIC ${THIRD_PARTY_DIR}/libwebp/${OHOS_ARCH}/lib/libwebpdemux.so.2)
+target_link_libraries(rnoh_ffmpeg_kit PUBLIC ${THIRD_PARTY_DIR}/libwebp/${OHOS_ARCH}/lib/libwebpmux.so.3)
+
+target_link_libraries(rnoh_ffmpeg_kit PUBLIC ${THIRD_PARTY_DIR}/libjpeg-turbo/${OHOS_ARCH}/lib/libjpeg.so.62)
+target_link_libraries(rnoh_ffmpeg_kit PUBLIC ${THIRD_PARTY_DIR}/libjpeg-turbo/${OHOS_ARCH}/lib/libturbojpeg.so.0)
+
+target_link_libraries(rnoh_ffmpeg_kit PUBLIC ${THIRD_PARTY_DIR}/tiff/${OHOS_ARCH}/lib/libtiff.so.6)
+target_link_libraries(rnoh_ffmpeg_kit PUBLIC ${THIRD_PARTY_DIR}/tiff/${OHOS_ARCH}/lib/libtiffxx.so.6)
+# 2025.04.24  end
 
 target_link_libraries(rnoh_ffmpeg_kit PUBLIC ${THIRD_PARTY_DIR}/x264/${OHOS_ARCH}/lib/libx264.so.164)
 target_link_libraries(rnoh_ffmpeg_kit PUBLIC ${THIRD_PARTY_DIR}/x265/${OHOS_ARCH}/lib/libx265.so.215)


### PR DESCRIPTION
# Summary

请解释此次更改的 **动机**，以下是一些帮助您的要点：

- 新增支持 openh264 多媒体编解码;
- 新增支持 opus 多媒体编解码;
- 新增支持 speex 多媒体编解码;
- 新增支持 webp 多媒体编解码;

## Test Plan

![image](https://github.com/user-attachments/assets/b083e09f-8daa-47ca-a870-87a855e43d86)
![image](https://github.com/user-attachments/assets/bcce5de9-d4d6-4339-b79c-4d4b48cf1cc3)
![image](https://github.com/user-attachments/assets/5bffd7e0-a6c6-422e-9e86-fa39c3615bc0)
![image](https://github.com/user-attachments/assets/da60c5ca-e6be-4c9f-997b-f0ea11c03cf9)



## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
