### PR TITLE
feat: 新增 getExternalLibraries 接口实现

### DIFF
--- a/harmony/ffmpeg_kit/src/main/cpp/RNFFmpegKitModule.cpp
+++ b/harmony/ffmpeg_kit/src/main/cpp/RNFFmpegKitModule.cpp
@@ -543,6 +543,28 @@ jsi::Value getPackageName(facebook::jsi::Runtime &rt, react::TurboModule &turboM
         });
 }
 
+jsi::Value getExternalLibraries(facebook::jsi::Runtime &rt, react::TurboModule &turboModule,
+                             const facebook::jsi::Value *args, size_t count) {
+    return facebook::react::createPromiseAsJSIValue(rt, [](jsi::Runtime &runtime,
+                                                           std::shared_ptr<facebook::react::Promise> promise) {
+            std::string libs[] = {
+                "dav1d",    "FFmpeg",   "lame",    "libogg",     "libvorbis",    "libvpx",     "openmp",   "rapidjson",
+                "vid.stab", "x264",     "x265",    "xvidcore",   "libass",        "libunibreak", "freetype2", "brotli",
+                "fribidi",  "harfbuzz", "libpng",  "fontconfig", "libxml2",       "xz",          "json-c",    "glib",
+                "nettle",   "gmp",      "libidn2", "libtasn1",   "gnutls",        "chromaprint", "openh264",  "opus",
+                "speex",    "libwebp",  "zstd",    "jbigkit",    "libjpeg-turbo", "libdeflate",  "tiff"};
+
+            size_t length = std::size(libs);
+            jsi::Array libArray(runtime, length);
+
+            for (int i = 0; i < length; ++i) {
+                libArray.setValueAtIndex(runtime, i, libs[i]);
+            }
+
+            promise->resolve(jsi::Value(runtime, libArray));
+        });
+}
+
 /**
  * enableRedirection：开启日志和统计重定向 (已完成)
  *
@@ -1388,6 +1410,7 @@ RNFFmpegKitModule::RNFFmpegKitModule(const ArkTSTurboModule::Context ctx, const 
         {"getPlatform", {0, rnoh::getPlatform}},
         {"getArch", {0, rnoh::getArch}},
         {"getPackageName", {0, rnoh::getPackageName}},
+        {"getExternalLibraries", {0, rnoh::getExternalLibraries}},
         {"isLTSBuild", {0, rnoh::isLTSBuild}},
         {"mediaInformationSessionExecute", {2, rnoh::mediaInformationSessionExecute}},
         {"asyncMediaInformationSessionExecute", {2, rnoh::asyncMediaInformationSessionExecute}},

--- a/src/NativeFFmpegKitModule.ts
+++ b/src/NativeFFmpegKitModule.ts
@@ -97,7 +97,7 @@ export interface Spec extends TurboModule {
   getMediaInformation(sessionId:number):Promise<MediaInformation>;
   mediaInformationJsonParserFrom(ffprobeJsonOutput:string):Promise<MediaInformation>;
   getPackageName():Promise<string>;
-  getExternalLibraries():Promise<string>;
+  getExternalLibraries():Promise<Array<string>>;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('NativeRNFFmpegKitModule');


### PR DESCRIPTION
# Summary

- 新增 getExternalLibraries 接口实现。

## Test Plan

![image](https://github.com/user-attachments/assets/067dd7d9-7e78-4aad-92e2-6902190f2dec)


## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
