### PR TITLE
fix:修复底层库返回时间戳为负数的情况，导致上层无法正确解析时间

### DIFF
--- a/harmony/ffmpeg_kit/src/main/cpp/RNFFmpegKitModule.cpp
+++ b/harmony/ffmpeg_kit/src/main/cpp/RNFFmpegKitModule.cpp
@@ -1524,8 +1524,8 @@ facebook::jsi::Object RNFFmpegKitModule::toMap(facebook::jsi::Runtime &runtime, 
     facebook::jsi::Object jsObj(runtime);
     
     jsObj.setProperty(runtime, "sessionId", jsi::Value(static_cast<int>(session->getSessionId())));
-    jsObj.setProperty(runtime, "createTime", jsi::Value(static_cast<int>(session->getCreateTime().time_since_epoch().count())));
-    jsObj.setProperty(runtime, "startTime", jsi::Value(static_cast<int>(session->getStartTime().time_since_epoch().count())));
+    jsObj.setProperty(runtime, "createTime", jsi::Value(atd::abs(static_cast<int>(session->getCreateTime().time_since_epoch().count()))));
+    jsObj.setProperty(runtime, "startTime", jsi::Value(std::abs(static_cast<int>(session->getStartTime().time_since_epoch().count()))));
     jsObj.setProperty(runtime, "command", jsi::String::createFromUtf8(runtime, session->getCommand()));
     
     if (session->isFFmpeg()) {


### PR DESCRIPTION
# Summary

- 修复底层库返回时间戳为负数的情况，导致上层无法正确解析时间。

## Test Plan

![image](https://github.com/user-attachments/assets/4c33aa38-462c-4ef4-bc3b-7d0548b7cd14)


## Checklist

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)

